### PR TITLE
Pass 0 for fourth argument to SYS_reboot

### DIFF
--- a/src/linux/reboot.c
+++ b/src/linux/reboot.c
@@ -3,5 +3,5 @@
 
 int reboot(int type)
 {
-	return syscall(SYS_reboot, 0xfee1dead, 672274793, type);
+	return syscall(SYS_reboot, 0xfee1dead, 672274793, type, 0);
 }


### PR DESCRIPTION
Musl is currently passing only 3 arguments to the reboot() syscall,
but REBOOT(2) indicates that it actually takes four arguments:

    int reboot(int magic, int magic2, int cmd, void *arg);

The fourth argument, 'arg' is used only when 'cmd' is equal to
LINUX_REBOOT_CMD_RESTART2 (0xa1b2c3d4). This is not exposed in
<sys/reboot.h> as an RB_* constant, but there is nothing stopping a
caller from passing it in 'type'.

This protects against any unintentional arguments.

Fixes #1